### PR TITLE
Add feature to skip upgrade if no changes detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ Only do this if you really want to deploy:
 cargo run -- --vdir ./example/helm-values upgrade
 ```
 
+## Additional Options
+
+### Bypass Upgrade on No Changes
+
+The `-b` or `--bypass-upgrade-on-no-changes` option allows you to bypass the upgrade process if no changes are detected. This can be useful to save time and resources when you are confident that no changes have been made to the release values.
+
+### Suboptions
+
+#### Yes
+
+The `-y` or `--yes` suboption can be used in conjunction with the `--bypass-upgrade-on-no-changes` option to automatically proceed with the upgrade even if no changes are detected. This is useful for automated scripts where manual intervention is not possible.
+
+#### No
+
+The `-n` or `--no` suboption can be used in conjunction with the `--bypass-upgrade-on-no-changes` option to automatically skip the upgrade if no changes are detected. This is useful when you want to ensure that upgrades are only performed when necessary without manual intervention.
+
+Example usage:
+
+```sh
+# Bypass upgrade on no changes and automatically proceed with the upgrade
+cargo run -- --vdir ./example/helm-values upgrade --bypass-upgrade-on-no-changes --yes
+cargo run -- --vdir ./example/helm-values upgrade -b -y
+
+
+# Bypass upgrade on no changes and automatically skip the upgrade
+cargo run -- --vdir ./example/helm-values upgrade --bypass-upgrade-on-no-changes --no
+cargo run -- --vdir ./example/helm-values upgrade -b -y
+```
+
 ## Config layout
 
 You can have zero or more environments.

--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: dev-cluster
+context: minikube
 locked: false

--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: minikube
+context: dev-cluster
 locked: false

--- a/src/command.rs
+++ b/src/command.rs
@@ -177,7 +177,7 @@ impl CommandLine {
         let kind = match output {
             Err(err) => Err(CommandErrorKind::FailedToStart { err }),
             Ok(output) => {
-                if output.status.success() {
+                if output.status.success() || exit_code == 2 {
                     Ok(())
                 } else {
                     Err(CommandErrorKind::BadExitCode {})

--- a/src/command.rs
+++ b/src/command.rs
@@ -22,6 +22,7 @@ pub struct CommandSuccess {
     pub stdout: String,
     pub stderr: String,
     pub duration: Duration,
+    pub exit_code: i32, // This field stores the exit code of the command to determine if it was successful or not, and whether or not there were any diffs.
 }
 
 impl CommandSuccess {
@@ -189,6 +190,7 @@ impl CommandLine {
                 cmd: self.clone(),
                 stdout,
                 stderr,
+                exit_code,
                 duration,
             }),
             Err(kind) => Err(CommandError {

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -370,7 +370,12 @@ pub async fn template(
 }
 
 // The DiffResult struct is used to store the exit code of the diff command.
-pub enum DiffResult { NoChanges, Changes, Errors, Unknown }
+pub enum DiffResult {
+    NoChanges,
+    Changes,
+    Errors,
+    Unknown,
+}
 
 /// Run the helm diff command.
 pub async fn diff(

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -376,6 +376,9 @@ pub enum DiffResult {
     Errors,
     Unknown,
 }
+async fn log_debug_message(tx: &MultiOutput, message: &str) {
+    tx.send(Message::Log(log!(Level::DEBUG, message))).await;
+}
 
 /// Run the helm diff command.
 pub async fn diff(
@@ -423,24 +426,24 @@ pub async fn diff(
         i_result.exit_code = command_success.exit_code;
         match command_success.exit_code {
             0 => {
-                debug!("No changes detected!"); // Exit code 0 indicates no changes.
+                log_debug_message(tx, "No changes detected!").await; // Exit code 0 indicates no changes.
                 DiffResult::NoChanges
             }
             1 => {
-                debug!("Errors encountered!"); // Exit code 1 indicates errors.
+                log_debug_message(tx, "Errors encountered!").await; // Exit code 1 indicates errors.
                 DiffResult::Errors
             }
             2 => {
-                debug!("Changes detected!"); // Exit code 2 indicates changes.
+                log_debug_message(tx, "Changes detected!").await; // Exit code 2 indicates changes.
                 DiffResult::Changes
             }
             _ => {
-                debug!("Unknown exit code"); // Any other exit code is considered unknown.
+                log_debug_message(tx, "Unknown exit code").await; // Any other exit code is considered unknown.
                 DiffResult::Unknown
             }
         }
     } else {
-        debug!("Other exception encountered"); // If the command result is an error, return Unknown.
+        log_debug_message(tx, "Other exception encountered").await; // If the command result is an error, return Unknown.
         DiffResult::Unknown
     };
 

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -446,7 +446,9 @@ pub async fn diff(
     tx.send(Message::InstallationResult(i_result)).await;
 
     // Return the exit code. Errors are no longer considered a failure and can be handled by the caller.
-    Ok(DiffResult { _exit_code: exit_code })
+    Ok(DiffResult {
+        _exit_code: exit_code,
+    })
 }
 
 /// Run the helm upgrade command.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@
 extern crate lazy_static;
 
 use std::collections::HashMap;
-use std::io::{self};
 use std::path::PathBuf;
 use std::str::{self, FromStr};
 use std::sync::Arc;
@@ -211,23 +210,8 @@ async fn run_job(
                             helm::upgrade(installation, helm_repos, tx, true).await?;
                             helm::upgrade(installation, helm_repos, tx, false).await?;
                         }
-                        UpgradeControl::BypassAndAssumeNo => {
-                            // Do nothing, as bypass_assume_no is an implicit case
-                        }
-                        UpgradeControl::Normal => {
-                            print!("No changes detected. Upgrade anyway? (Y/n): ");
-
-                            let mut input = String::new();
-                            if let Err(e) = io::stdin().read_line(&mut input) {
-                                eprintln!("Failed to read input: {e}");
-                                return Err(anyhow::anyhow!("Failed to read input"));
-                            }
-                            let input = input.trim().to_lowercase();
-
-                            if input == "y" || input == "yes" || input.is_empty() {
-                                helm::upgrade(installation, helm_repos, tx, true).await?;
-                                helm::upgrade(installation, helm_repos, tx, false).await?;
-                            }
+                        UpgradeControl::BypassAndAssumeNo | UpgradeControl::Normal => {
+                            // Do nothing, as these are implicit or default cases
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,6 @@ mod duration;
 
 mod utils;
 
-
 /// An individual update
 #[derive(Clone, Debug)]
 pub struct Update {
@@ -187,16 +186,16 @@ where
 
 // Define the possible results of a job.
 enum JobResult {
-    Unit, // Represents a unit result.
+    Unit,                   // Represents a unit result.
     Diff(helm::DiffResult), // Represents a diff result.
 }
 
 // Asynchronously run a job based on the provided command.
 async fn run_job(
-    command: &Request, // The command to execute.
-    helm_repos: &HelmReposLock, // The helm repositories lock.
+    command: &Request,                // The command to execute.
+    helm_repos: &HelmReposLock,       // The helm repositories lock.
     installation: &Arc<Installation>, // The installation details.
-    tx: &MultiOutput, // The multi-output channel.
+    tx: &MultiOutput,                 // The multi-output channel.
 ) -> Result<JobResult> {
     match command {
         // Handle the Upgrade request.
@@ -220,8 +219,10 @@ async fn run_job(
             // Run the helm diff command.
             let diff_result = helm::diff(installation, helm_repos, tx).await?;
             // Return the diff result.
-            Ok(JobResult::Diff(helm::DiffResult { _exit_code: diff_result._exit_code }))
-        },
+            Ok(JobResult::Diff(helm::DiffResult {
+                _exit_code: diff_result._exit_code,
+            }))
+        }
         Request::Test { .. } => {
             helm::outdated(installation, helm_repos, tx).await?;
             helm::lint(installation, tx).await?;

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -216,6 +216,7 @@ fn process_message(msg: &Arc<Message>, state: &mut State) {
                 command,
                 result,
                 installation,
+                #[allow(unused_variables)] // Suppress warning for this variable
                 exit_code,
             } = hr.as_ref();
             let result_str = hr.result_line();

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -216,7 +216,7 @@ fn process_message(msg: &Arc<Message>, state: &mut State) {
                 command,
                 result,
                 installation,
-                _exit_code, // This field is not used in this function, but it is part of the HelmResult struct.
+                exit_code,
             } = hr.as_ref();
             let result_str = hr.result_line();
 

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -216,7 +216,7 @@ fn process_message(msg: &Arc<Message>, state: &mut State) {
                 command,
                 result,
                 installation,
-                _exit_code // This field is not used in this function, but it is part of the HelmResult struct.
+                _exit_code, // This field is not used in this function, but it is part of the HelmResult struct.
             } = hr.as_ref();
             let result_str = hr.result_line();
 

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -216,6 +216,7 @@ fn process_message(msg: &Arc<Message>, state: &mut State) {
                 command,
                 result,
                 installation,
+                _exit_code // This field is not used in this function, but it is part of the HelmResult struct.
             } = hr.as_ref();
             let result_str = hr.result_line();
 


### PR DESCRIPTION
**Description**

This PR introduces a feature to skip the Helm upgrade if no changes are detected. This is achieved by evaluating the detailed exit code returned by the helm diff command. The exit codes are interpreted as follows:

_Revised this enum for accuracy on 8.26_

0.  No changes detected.
1.  Errors encountered.
2.  Changes detected.

This feature addresses the need to conditionally trigger Helm deployments based on whether there are actual changes, as discussed in [Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54).
.
**Changes Made**
Added the --detailed-exitcode flag to the helm diff command.
Evaluated the exit code to determine if changes were detected or if errors were encountered.
Updated the diff function to return a DiffResult with the appropriate exit code.

**Testing**

Ensure that the helm diff command returns the correct exit codes.
Verify that the upgrade is skipped if no changes are detected.
Confirm that changes are applied if the exit code indicates changes.
Handle errors appropriately based on the exit code.

**References**
[Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54)
[Issue #4 - helm-sops](https://github.com/camptocamp/helm-sops/issues/4)
